### PR TITLE
Add inline function specifiers to prevent multiple function defitions

### DIFF
--- a/include/ws_client/Message.hpp
+++ b/include/ws_client/Message.hpp
@@ -108,7 +108,7 @@ struct Message
 };
 
 // iostream operator for Message
-std::ostream& operator<<(std::ostream& os, const Message& msg)
+inline std::ostream& operator<<(std::ostream& os, const Message& msg)
 {
     os << "Message(type=" << to_string(msg.type) << ", data=" << msg.to_string_view() << ")";
     return os;
@@ -121,7 +121,7 @@ struct SendOptions
      * Only applicable if permessage-deflate compression
      * was negotiated during the WebSocket handshake,
      * otherwise this option is ignored.
-     * 
+     *
      * Default: `true`
      */
     bool compress{true};
@@ -130,14 +130,14 @@ struct SendOptions
      * Timeout for sending the message, in milliseconds.
      * If the message cannot be sent within this time,
      * the send operation will fail with a timeout error.
-     * 
+     *
      * Default: 30 seconds.
      */
     std::chrono::milliseconds timeout{std::chrono::seconds(30)};
 };
 
 // iostream operator for SendOptions
-std::ostream& operator<<(std::ostream& os, const SendOptions& opts)
+inline std::ostream& operator<<(std::ostream& os, const SendOptions& opts)
 {
     os << "SendOptions(compress=" << opts.compress << ")";
     return os;

--- a/include/ws_client/transport/builtin/AddressInfo.hpp
+++ b/include/ws_client/transport/builtin/AddressInfo.hpp
@@ -23,7 +23,7 @@ enum class AddrType : uint8_t
 };
 
 // to_string
-constexpr const string_view to_string(AddrType type) noexcept
+inline constexpr const string_view to_string(AddrType type) noexcept
 {
     switch (type)
     {
@@ -39,7 +39,7 @@ constexpr const string_view to_string(AddrType type) noexcept
 }
 
 // ostream operator
-std::ostream& operator<<(std::ostream& os, AddrType type)
+inline std::ostream& operator<<(std::ostream& os, AddrType type)
 {
     os << to_string(type);
     return os;
@@ -47,7 +47,7 @@ std::ostream& operator<<(std::ostream& os, AddrType type)
 
 /**
  * Represents a resolved POSIX address info.
- * 
+ *
  * Currently only supports IPv4 (`AF_INET`) and IPv6 (`AF_INET6`) address families.
  */
 class AddressInfo

--- a/include/ws_client/utils/base64.hpp
+++ b/include/ws_client/utils/base64.hpp
@@ -9,7 +9,7 @@ using std::string;
 /**
  * Base64 encodes binary data as string.
  */
-string base64_encode(const unsigned char* data, const size_t len)
+inline string base64_encode(const unsigned char* data, const size_t len)
 {
     static constexpr char encode_table[] =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/include/ws_client/utils/utf8.hpp
+++ b/include/ws_client/utils/utf8.hpp
@@ -26,7 +26,7 @@ inline bool is_valid_utf8(const char* str, int len) noexcept
  * This function is not optimized, therefore slow, and should be used only
  * if SIMDUTF is not available.
  */
-bool is_valid_utf8(const char* str, int len)
+inline bool is_valid_utf8(const char* str, int len)
 {
     const unsigned char* s = reinterpret_cast<const unsigned char*>(str);
     for (int i = 0; i < len;)


### PR DESCRIPTION
Some functions lack the `inline` specifier so GCC complains about multiple definitions of the these functions. This PR adds the missing `inline` specifiers. 