### PR TITLE
Add missing "#include <cassert>"

### DIFF
--- a/include/ws_client/utils/Timeout.hpp
+++ b/include/ws_client/utils/Timeout.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sys/time.h>
+#include <cassert>
 #include <chrono>
 
 namespace ws_client
@@ -10,7 +11,7 @@ using namespace std::chrono;
 /**
  * Utility class to update a timeout by incorporating the elapsed time.
  * The start time is initialized to the current time.
- * 
+ *
  * Template Parameters:
  * DT - Duration type, defaults to milliseconds
  * ClockT - Clock type, defaults to steady_clock for monotonic time measurement


### PR DESCRIPTION
There is a missing `#include <cassert>` which breaks compilation.
This PR adds the missing include.